### PR TITLE
Update faraday to 2.14.3 to fix CVE-2026-54297

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,11 +17,11 @@ GEM
     dotenv (3.2.0)
     excon (1.3.2)
       logger
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     google-protobuf (4.33.4)
       bigdecimal
@@ -33,7 +33,7 @@ GEM
       googleapis-common-protos-types (~> 1.0)
     grpc-tools (1.76.0)
     io-console (0.8.2)
-    json (2.19.5)
+    json (2.20.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -134,20 +134,20 @@ CHECKSUMS
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   bitstring (1.0.0) sha256=64a5c05c742019af09881b1058f58dc8be176310724f4d3c18ebd43877956fbd
   blockenspiel (0.5.0) sha256=a8f7b3e06aab850f2deed3fe7b4037e522640bc9d61d76d9ce17175b880ee0c0
-  bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
+  bundler (4.0.15) sha256=a4ceb882fe94a0e0ac63cd0813932bbfd631a14e5ac0b7975189b19a4d28d9e7
   certifi (2018.01.18) sha256=d5aff04a27045255a4829823496a974dc1cc2c04a777675b3056b0c0952ce9e3
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
   excon (1.3.2) sha256=a089babe98638e58042a7d542b2bbd183304527e33d612b6dde22fa491a544a5
-  faraday (2.14.2) sha256=73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad
-  faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
+  faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
+  faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   google-protobuf (4.33.4) sha256=86921935b023ed0d872d6e84382e79016c91689be0520d614c74426778f13c16
   googleapis-common-protos-types (1.22.0) sha256=f97492b77bd6da0018c860d5004f512fe7cd165554d7019a8f4df6a56fbfc4c7
   grpc (1.76.0) sha256=112416fa42153aee440fd1b975de4b2bf746656df071bace97c197a6b5575598
   grpc-tools (1.76.0) sha256=1b943edf89fd5d125c3476d657b4d89ac85adc6144c5e00a10ed750631f1228e
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
-  json (2.19.5) sha256=218a18553e4801d579ca7e0f5bc72bafd776d7397238a1fb4e74db5b0a812c59
+  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
@@ -183,4 +183,4 @@ CHECKSUMS
   versionomy (0.5.0) sha256=636c8f9174c884034d1b24354a479c579b32e7839d897729b97e079aff251444
 
 BUNDLED WITH
-  4.0.4
+  4.0.15


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description, motivation and context

Updates the `faraday` gem from 2.14.2 to 2.14.3 to resolve a HIGH severity security vulnerability (CVE-2026-54297 / GHSA-98m9-hrrm-r99r).

**Vulnerability:** `Faraday::NestedParamsEncoder` decodes nested query strings without enforcing a maximum nesting depth. A crafted query string with deeply nested parameters causes Ruby to build a deeply nested Hash structure, and the internal `dehash` routine recursively walks it without a depth limit. At sufficient depth, Ruby raises an uncaught `SystemStackError`, crashing the calling thread/worker — leading to denial of service.

**Changes to Gemfile.lock:**
- `faraday`: 2.14.2 → 2.14.3 (security fix)
- `faraday-net_http`: 3.4.2 → 3.4.4 (transitive dependency update)
- `json`: 2.19.5 → 2.20.0 (transitive dependency update)

## Related tickets(s), PR(s) or slack message:

- Linear: SEC-109
- [Dependabot Alert](https://github.com/RenoFi/salesforce-pub-sub-api-rb/security/dependabot/8)
- CVE-2026-54297

## Security

This PR updates an existing third party dependency to a patched version to resolve a known security vulnerability. No new dependencies are introduced.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SEC-109](https://linear.app/renofi/issue/SEC-109/dependabot-salesforce-pub-sub-api-rb-1-open-security-alerts)

<div><a href="https://cursor.com/agents/bc-a7243638-7e26-4d74-b4ec-e6f1de6fd61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7243638-7e26-4d74-b4ec-e6f1de6fd61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

